### PR TITLE
feat: implement scenario manager

### DIFF
--- a/Assets/JsonData.meta
+++ b/Assets/JsonData.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7e7b9f22a184aa644a7f18c3b9444b9f
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/JsonData/EnemyLists.json
+++ b/Assets/JsonData/EnemyLists.json
@@ -1,0 +1,37 @@
+{
+    "waveList": [
+        {
+            "wave": 1,
+            "enemyHPOffset": 1,
+            "spawnDelay": 1.0,
+            "enemyList": [
+                0,
+                0,
+                0
+            ]
+        },
+        {
+            "wave": 2,
+            "enemyHPOffset": 2,
+            "spawnDelay": 1.0,
+            "enemyList": [
+                0,
+                0,
+                0,
+                0
+            ]
+        },
+        {
+            "wave": 3,
+            "enemyHPOffset": 3,
+            "spawnDelay": 1.0,
+            "enemyList": [
+                0,
+                0,
+                0,
+                0,
+                0
+            ]
+        }
+    ]
+}

--- a/Assets/JsonData/EnemyLists.json.meta
+++ b/Assets/JsonData/EnemyLists.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 904dcfa4dd110cd428b7f5dffce8137c
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -1841,6 +1841,51 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1131538119}
   m_CullTransparentMesh: 1
+--- !u!1 &1166434724
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1166434726}
+  - component: {fileID: 1166434725}
+  m_Layer: 0
+  m_Name: ScenarioManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1166434725
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1166434724}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 588a84752a793754eb29ab9fbaa43b71, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _gameManager: {fileID: 1689355136}
+--- !u!4 &1166434726
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1166434724}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 8
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1171023037
 GameObject:
   m_ObjectHideFlags: 0
@@ -2745,6 +2790,7 @@ MonoBehaviour:
   sp: 5000
   towerManager: {fileID: 497353759}
   enemyManager: {fileID: 1417149470}
+  scenarioManager: {fileID: 1166434725}
   uiManager: {fileID: 1013384291}
 --- !u!1 &1721327702
 GameObject:

--- a/Assets/Scripts/Enemy.cs
+++ b/Assets/Scripts/Enemy.cs
@@ -24,13 +24,9 @@ public partial class Enemy // SerializeField
 
 public partial class Enemy : MonoBehaviour
 {
-	private void Awake()
-	{
-	}
-
 	void Update() {
-		Move();
-		GetProgressToGoal();
+		_Move();
+		_GetProgressToGoal();
 	}
 }
 
@@ -41,45 +37,48 @@ public partial class Enemy // body
 	private int _currentLine = 0;
 	private float _runDistance;
 
-	private void _Init(EnemyData enemyData, int wave, EnemyManager enemyManager)
+	private void _Init(EnemyData enemyData, int hpOffset, EnemyManager enemyManager)
 	{
 		_enemyManager = enemyManager;
 		_wayPoints = _enemyManager.wayPoints;
 		speed = enemyData.speed;
-		maxHealth = enemyData.health;
-		currHealth = enemyData.health;
+		maxHealth = enemyData.health * hpOffset;
+		currHealth = maxHealth;
 		sp = enemyData.sp;
 		_enemySpriteRenderer.sprite = enemyData.sprite;
 
 		progressToGoal = 0f;
 		_runDistance = 0f;
+
+		textMesh.text = currHealth.ToString();
 	}
 
-	private void Move() {
+	private void _Move() {
 		transform.position = Vector2.MoveTowards
 		(transform.position,
 			_wayPoints[_currentLine].position,
 			speed * Time.deltaTime);
 
-		if (Vector2.SqrMagnitude(transform.position - _wayPoints[_currentLine].transform.position) <= 0.01f)
+		if (Vector2.SqrMagnitude(transform.position - _wayPoints[_currentLine].transform.position) <= 0.000001f)
 			_currentLine++;
 		if (_currentLine == _wayPoints.Length)
-			Die();
+			_Die();
 	}
 
-	private void Die() {
+	private void _Die() {
 		_enemyManager.EnemyGoal();
 		_enemyManager.DestroyEnemy(this);
+		_enemyManager.SetGeneralTarget();
 	}
 
 	private void _OnDamage(float damage) {
 		currHealth -= damage;
 		textMesh.text = currHealth.ToString();
 		if (currHealth <= 0)
-			Die();
+			_Die();
 	}
 
-	private void GetProgressToGoal()
+	private void _GetProgressToGoal()
 	{
 		_runDistance += speed * Time.deltaTime;
 		progressToGoal = _runDistance / _enemyManager.maxDistToGoal;

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -5,9 +5,12 @@ public partial class GameManager
 	public int playerHealth { get; private set; } = 3;
 	public int sp = 500;
 	public int towerCost { get; private set; } = 10;
+
 	public TowerManager towerManager;
 	public EnemyManager enemyManager;
+	public ScenarioManager scenarioManager;
 	public UIManager uiManager;
+
 	public void CreateTower() => _CreateTower();
 	public void OnDamage(int damage) => _OnDamage(damage);
 }
@@ -17,12 +20,13 @@ public partial class GameManager : MonoBehaviour
 	private void Awake() {
 		//towerManager.Init(this);
 		enemyManager.Init();
+		scenarioManager.Init();
 	}
 }
 
 public partial class GameManager
 {
-	public void _CreateTower() {
+	private void _CreateTower() {
 		if (sp >= towerCost && towerManager.AddTower())
 		{
 			sp -= towerCost;
@@ -32,7 +36,7 @@ public partial class GameManager
 		}
 	}
 
-	public void _OnDamage(int damage)
+	private void _OnDamage(int damage)
 	{
 		if (playerHealth > 0)
 		{

--- a/Assets/Scripts/JsonConverter.meta
+++ b/Assets/Scripts/JsonConverter.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 63f1f319ed97db2409fb5ed66d031b14
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Scenario.meta
+++ b/Assets/Scripts/Scenario.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8a2e4ba4af106a046bdb32788c755323
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Scenario/ScenarioList.cs
+++ b/Assets/Scripts/Scenario/ScenarioList.cs
@@ -1,0 +1,74 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+[System.Serializable]
+public class ScenarioList
+{
+    public int wave;
+    public int enemyHPOffset;
+    public float spawnDelay;
+    public List<int> enemyList = new List<int>();
+
+
+    public ScenarioList()
+    {
+        wave = 0;
+        enemyHPOffset = 0;
+        spawnDelay = 0;
+    }
+
+    public ScenarioList(ScenarioList other)
+    {
+        wave = other.wave;
+        enemyHPOffset = other.enemyHPOffset;
+        spawnDelay = other.spawnDelay;
+        enemyList.AddRange(other.enemyList);
+    }
+
+    public bool ValidateList()
+    {
+        for (int i = 0; i < enemyList.Count; i++)
+        {
+            if (enemyList[i] < 0)
+                return false;
+        }
+        if (wave < 0 || enemyHPOffset < 1 || spawnDelay < 0)
+            return false;
+        return true;
+    }
+}
+
+[System.Serializable]
+public class ScenarioLists
+{
+    public List<ScenarioList> waveList = new List<ScenarioList>();
+
+    // This is for making Json files
+    //public ScenarioLists()
+    //{
+    //    waveList.Add(new ScenarioList());
+    //    waveList.Add(new ScenarioList());
+    //    waveList.Add(new ScenarioList());
+    //}
+
+    public bool ValidateLists()
+    {
+        for (int i = 0; i < waveList.Count; i++)
+        {
+            if (waveList[i].ValidateList() == false)
+            {
+                return false;
+            }
+                
+            if (i != waveList.Count - 1)
+            {
+                if (waveList[i].wave >= waveList[i + 1].wave)
+                {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+}

--- a/Assets/Scripts/Scenario/ScenarioList.cs.meta
+++ b/Assets/Scripts/Scenario/ScenarioList.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e4becbf5917fff9418d3633797f205ea
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Scenario/ScenarioManager.cs
+++ b/Assets/Scripts/Scenario/ScenarioManager.cs
@@ -1,0 +1,71 @@
+using System.Collections;
+using UnityEngine;
+
+public partial class ScenarioManager // IO
+{
+    public bool isWaveOver { get; private set; }
+    public int wave { get; private set; }
+    public int maxWave { get; private set; }
+    public float waveStartDelay { get; private set; }
+
+
+    public void Init() => _Init();
+    
+}
+
+public partial class ScenarioManager // SerializeField
+{
+    [SerializeField] private GameManager _gameManager;
+}
+
+public partial class ScenarioManager : MonoBehaviour
+{
+    // Update is called once per frame
+    void Update()
+    {
+        _StartNewWave();
+    }
+}
+
+public partial class ScenarioManager // body
+{
+    private string _loadPath;
+    private string _fileName;
+
+    private ScenarioLists _scenarioLists;
+    private JsonConverter _jsonConverter;
+
+    private ScenarioList _currentList;
+
+
+    private void _Init()
+    {
+        _loadPath = Application.dataPath + "/JsonData";
+        _fileName = "EnemyLists";
+
+        _jsonConverter = new JsonConverter();
+        _scenarioLists = _jsonConverter.LoadJsonFile<ScenarioLists>(_loadPath, _fileName);
+        if (_scenarioLists.ValidateLists() == false)
+        {
+            Debug.LogError("ScenarioLists Validation Fails!");
+        }
+
+        wave = 0;
+        maxWave = _scenarioLists.waveList.Count;
+        waveStartDelay = 3f;
+    }
+
+    private void _StartNewWave()
+    {
+        if (wave >= maxWave)
+        {
+            return;
+        }
+        else if (_gameManager.enemyManager.State == EMState.waiting)
+        {
+            _currentList = new ScenarioList(_scenarioLists.waveList[wave]);
+            _gameManager.enemyManager.InjectScenario(_currentList, waveStartDelay);
+            wave = wave + 1;
+        }
+    }
+}

--- a/Assets/Scripts/Scenario/ScenarioManager.cs.meta
+++ b/Assets/Scripts/Scenario/ScenarioManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 588a84752a793754eb29ab9fbaa43b71
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,11 +1,11 @@
 {
   "dependencies": {
-    "com.unity.collab-proxy": "1.17.2",
+    "com.unity.collab-proxy": "1.17.6",
     "com.unity.feature.2d": "1.0.0",
     "com.unity.ide.rider": "3.0.15",
     "com.unity.ide.visualstudio": "2.0.16",
     "com.unity.ide.vscode": "1.2.5",
-    "com.unity.test-framework": "1.1.31",
+    "com.unity.test-framework": "1.1.33",
     "com.unity.textmeshpro": "3.0.6",
     "com.unity.timeline": "1.6.4",
     "com.unity.ugui": "1.0.0",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -95,7 +95,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.collab-proxy": {
-      "version": "1.17.2",
+      "version": "1.17.6",
       "depth": 0,
       "source": "registry",
       "dependencies": {
@@ -175,7 +175,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.test-framework": {
-      "version": "1.1.31",
+      "version": "1.1.33",
       "depth": 0,
       "source": "registry",
       "dependencies": {

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -460,6 +460,43 @@ PlayerSettings:
       m_Height: 36
       m_Kind: 0
       m_SubKind: 
+  - m_BuildTarget: tvOS
+    m_Icons:
+    - m_Textures: []
+      m_Width: 1280
+      m_Height: 768
+      m_Kind: 0
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 800
+      m_Height: 480
+      m_Kind: 0
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 400
+      m_Height: 240
+      m_Kind: 0
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 4640
+      m_Height: 1440
+      m_Kind: 1
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 2320
+      m_Height: 720
+      m_Kind: 1
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 3840
+      m_Height: 1440
+      m_Kind: 1
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 1920
+      m_Height: 720
+      m_Kind: 1
+      m_SubKind: 
   m_BuildTargetBatching: []
   m_BuildTargetGraphicsJobs:
   - m_BuildTarget: MacStandaloneSupport
@@ -733,6 +770,7 @@ PlayerSettings:
   ps4videoRecordingFeaturesUsed: 0
   ps4contentSearchFeaturesUsed: 0
   ps4CompatibilityPS5: 0
+  ps4AllowPS5Detection: 0
   ps4GPU800MHz: 1
   ps4attribEyeToEyeDistanceSettingVR: 0
   ps4IncludedModules: []

--- a/UserSettings/Layouts/default-2021.dwlt
+++ b/UserSettings/Layouts/default-2021.dwlt
@@ -15,16 +15,42 @@ MonoBehaviour:
   m_PixelRect:
     serializedVersion: 2
     x: 0
-    y: 53
-    width: 1440
-    height: 847
+    y: 43
+    width: 1920
+    height: 997
   m_ShowMode: 4
-  m_Title: Hierarchy
-  m_RootView: {fileID: 2}
+  m_Title: Game
+  m_RootView: {fileID: 3}
   m_MinSize: {x: 875, y: 492}
   m_MaxSize: {x: 10000, y: 10000}
   m_Maximized: 1
 --- !u!114 &2
+MonoBehaviour:
+  m_ObjectHideFlags: 52
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 12006, guid: 0000000000000000e000000000000000, type: 0}
+  m_Name: GameView
+  m_EditorClassIdentifier: 
+  m_Children: []
+  m_Position:
+    serializedVersion: 2
+    x: 741
+    y: 0
+    width: 774
+    height: 947
+  m_MinSize: {x: 202, y: 221}
+  m_MaxSize: {x: 4002, y: 4021}
+  m_ActualView: {fileID: 12}
+  m_Panes:
+  - {fileID: 12}
+  m_Selected: 0
+  m_LastSelected: 0
+--- !u!114 &3
 MonoBehaviour:
   m_ObjectHideFlags: 52
   m_CorrespondingSourceObject: {fileID: 0}
@@ -37,22 +63,22 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Children:
-  - {fileID: 3}
-  - {fileID: 5}
   - {fileID: 4}
+  - {fileID: 6}
+  - {fileID: 5}
   m_Position:
     serializedVersion: 2
     x: 0
     y: 0
-    width: 1440
-    height: 847
+    width: 1920
+    height: 997
   m_MinSize: {x: 875, y: 300}
   m_MaxSize: {x: 10000, y: 10000}
   m_UseTopView: 1
   m_TopViewHeight: 30
   m_UseBottomView: 1
   m_BottomViewHeight: 20
---- !u!114 &3
+--- !u!114 &4
 MonoBehaviour:
   m_ObjectHideFlags: 52
   m_CorrespondingSourceObject: {fileID: 0}
@@ -69,12 +95,12 @@ MonoBehaviour:
     serializedVersion: 2
     x: 0
     y: 0
-    width: 1440
+    width: 1920
     height: 30
   m_MinSize: {x: 0, y: 0}
   m_MaxSize: {x: 0, y: 0}
   m_LastLoadedLayoutName: 
---- !u!114 &4
+--- !u!114 &5
 MonoBehaviour:
   m_ObjectHideFlags: 52
   m_CorrespondingSourceObject: {fileID: 0}
@@ -90,37 +116,11 @@ MonoBehaviour:
   m_Position:
     serializedVersion: 2
     x: 0
-    y: 827
-    width: 1440
+    y: 977
+    width: 1920
     height: 20
   m_MinSize: {x: 0, y: 0}
   m_MaxSize: {x: 0, y: 0}
---- !u!114 &5
-MonoBehaviour:
-  m_ObjectHideFlags: 52
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 1
-  m_Script: {fileID: 12010, guid: 0000000000000000e000000000000000, type: 0}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Children:
-  - {fileID: 6}
-  - {fileID: 9}
-  - {fileID: 12}
-  m_Position:
-    serializedVersion: 2
-    x: 0
-    y: 30
-    width: 1440
-    height: 797
-  m_MinSize: {x: 300, y: 200}
-  m_MaxSize: {x: 24288, y: 16192}
-  vertical: 0
-  controlID: 128
 --- !u!114 &6
 MonoBehaviour:
   m_ObjectHideFlags: 52
@@ -135,17 +135,18 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Children:
   - {fileID: 7}
+  - {fileID: 2}
   - {fileID: 8}
   m_Position:
     serializedVersion: 2
     x: 0
-    y: 0
-    width: 748.5
-    height: 797
-  m_MinSize: {x: 100, y: 200}
-  m_MaxSize: {x: 8096, y: 16192}
-  vertical: 1
-  controlID: 32
+    y: 30
+    width: 1920
+    height: 947
+  m_MinSize: {x: 300, y: 200}
+  m_MaxSize: {x: 24288, y: 16192}
+  vertical: 0
+  controlID: 75
 --- !u!114 &7
 MonoBehaviour:
   m_ObjectHideFlags: 52
@@ -163,13 +164,13 @@ MonoBehaviour:
     serializedVersion: 2
     x: 0
     y: 0
-    width: 748.5
-    height: 409
+    width: 741
+    height: 947
   m_MinSize: {x: 201, y: 221}
   m_MaxSize: {x: 4001, y: 4021}
-  m_ActualView: {fileID: 15}
+  m_ActualView: {fileID: 11}
   m_Panes:
-  - {fileID: 15}
+  - {fileID: 11}
   m_Selected: 0
   m_LastSelected: 0
 --- !u!114 &8
@@ -180,24 +181,23 @@ MonoBehaviour:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 0}
   m_Enabled: 1
-  m_EditorHideFlags: 1
-  m_Script: {fileID: 12006, guid: 0000000000000000e000000000000000, type: 0}
-  m_Name: GameView
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 12010, guid: 0000000000000000e000000000000000, type: 0}
+  m_Name: 
   m_EditorClassIdentifier: 
-  m_Children: []
+  m_Children:
+  - {fileID: 9}
+  - {fileID: 10}
   m_Position:
     serializedVersion: 2
-    x: 0
-    y: 409
-    width: 748.5
-    height: 388
-  m_MinSize: {x: 201, y: 221}
-  m_MaxSize: {x: 4001, y: 4021}
-  m_ActualView: {fileID: 16}
-  m_Panes:
-  - {fileID: 16}
-  m_Selected: 0
-  m_LastSelected: 0
+    x: 1515
+    y: 0
+    width: 405
+    height: 947
+  m_MinSize: {x: 100, y: 200}
+  m_MaxSize: {x: 8096, y: 16192}
+  vertical: 1
+  controlID: 76
 --- !u!114 &9
 MonoBehaviour:
   m_ObjectHideFlags: 52
@@ -206,23 +206,25 @@ MonoBehaviour:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 0}
   m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 12010, guid: 0000000000000000e000000000000000, type: 0}
-  m_Name: 
+  m_EditorHideFlags: 1
+  m_Script: {fileID: 12006, guid: 0000000000000000e000000000000000, type: 0}
+  m_Name: InspectorWindow
   m_EditorClassIdentifier: 
-  m_Children:
-  - {fileID: 10}
-  - {fileID: 11}
+  m_Children: []
   m_Position:
     serializedVersion: 2
-    x: 748.5
+    x: 0
     y: 0
-    width: 359
-    height: 797
-  m_MinSize: {x: 100, y: 200}
-  m_MaxSize: {x: 8096, y: 16192}
-  vertical: 1
-  controlID: 83
+    width: 405
+    height: 481
+  m_MinSize: {x: 276, y: 71}
+  m_MaxSize: {x: 4001, y: 4021}
+  m_ActualView: {fileID: 15}
+  m_Panes:
+  - {fileID: 15}
+  - {fileID: 14}
+  m_Selected: 0
+  m_LastSelected: 1
 --- !u!114 &10
 MonoBehaviour:
   m_ObjectHideFlags: 52
@@ -231,128 +233,26 @@ MonoBehaviour:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 0}
   m_Enabled: 1
-  m_EditorHideFlags: 1
+  m_EditorHideFlags: 0
   m_Script: {fileID: 12006, guid: 0000000000000000e000000000000000, type: 0}
-  m_Name: 
+  m_Name: SceneHierarchyWindow
   m_EditorClassIdentifier: 
   m_Children: []
   m_Position:
     serializedVersion: 2
     x: 0
-    y: 0
-    width: 359
-    height: 408
-  m_MinSize: {x: 202, y: 221}
-  m_MaxSize: {x: 4002, y: 4021}
-  m_ActualView: {fileID: 17}
+    y: 481
+    width: 405
+    height: 466
+  m_MinSize: {x: 201, y: 221}
+  m_MaxSize: {x: 4001, y: 4021}
+  m_ActualView: {fileID: 13}
   m_Panes:
-  - {fileID: 17}
-  m_Selected: 0
-  m_LastSelected: 0
---- !u!114 &11
-MonoBehaviour:
-  m_ObjectHideFlags: 52
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 12006, guid: 0000000000000000e000000000000000, type: 0}
-  m_Name: ProjectBrowser
-  m_EditorClassIdentifier: 
-  m_Children: []
-  m_Position:
-    serializedVersion: 2
-    x: 0
-    y: 408
-    width: 359
-    height: 389
-  m_MinSize: {x: 232, y: 271}
-  m_MaxSize: {x: 10002, y: 10021}
-  m_ActualView: {fileID: 18}
-  m_Panes:
-  - {fileID: 18}
-  m_Selected: 0
-  m_LastSelected: 0
---- !u!114 &12
-MonoBehaviour:
-  m_ObjectHideFlags: 52
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 12010, guid: 0000000000000000e000000000000000, type: 0}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Children:
   - {fileID: 13}
-  - {fileID: 14}
-  m_Position:
-    serializedVersion: 2
-    x: 1107.5
-    y: 0
-    width: 332.5
-    height: 797
-  m_MinSize: {x: 100, y: 200}
-  m_MaxSize: {x: 8096, y: 16192}
-  vertical: 1
-  controlID: 129
---- !u!114 &13
-MonoBehaviour:
-  m_ObjectHideFlags: 52
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 1
-  m_Script: {fileID: 12006, guid: 0000000000000000e000000000000000, type: 0}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Children: []
-  m_Position:
-    serializedVersion: 2
-    x: 0
-    y: 0
-    width: 332.5
-    height: 405
-  m_MinSize: {x: 276, y: 71}
-  m_MaxSize: {x: 4001, y: 4021}
-  m_ActualView: {fileID: 19}
-  m_Panes:
-  - {fileID: 19}
+  - {fileID: 16}
   m_Selected: 0
-  m_LastSelected: 0
---- !u!114 &14
-MonoBehaviour:
-  m_ObjectHideFlags: 52
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 12006, guid: 0000000000000000e000000000000000, type: 0}
-  m_Name: ConsoleWindow
-  m_EditorClassIdentifier: 
-  m_Children: []
-  m_Position:
-    serializedVersion: 2
-    x: 0
-    y: 405
-    width: 332.5
-    height: 392
-  m_MinSize: {x: 101, y: 121}
-  m_MaxSize: {x: 4001, y: 4021}
-  m_ActualView: {fileID: 20}
-  m_Panes:
-  - {fileID: 20}
-  m_Selected: 0
-  m_LastSelected: 0
---- !u!114 &15
+  m_LastSelected: 1
+--- !u!114 &11
 MonoBehaviour:
   m_ObjectHideFlags: 52
   m_CorrespondingSourceObject: {fileID: 0}
@@ -373,9 +273,9 @@ MonoBehaviour:
   m_Pos:
     serializedVersion: 2
     x: 0
-    y: 83
-    width: 747.5
-    height: 388
+    y: 73
+    width: 740
+    height: 926
   m_ViewDataDictionary: {fileID: 0}
   m_OverlayCanvas:
     m_LastAppliedPresetName: Default
@@ -599,9 +499,9 @@ MonoBehaviour:
   m_PlayAudio: 0
   m_AudioPlay: 0
   m_Position:
-    m_Target: {x: 0.22951633, y: -2.9362779, z: 0.04050275}
+    m_Target: {x: -0.4851597, y: -0.021387769, z: -0.0074471547}
     speed: 2
-    m_Value: {x: 0.22951633, y: -2.9362779, z: 0.04050275}
+    m_Value: {x: -0.4851597, y: -0.021387769, z: -0.0074471547}
   m_RenderMode: 0
   m_CameraMode:
     drawMode: 0
@@ -652,9 +552,9 @@ MonoBehaviour:
     speed: 2
     m_Value: {x: 0, y: 0, z: 0, w: 1}
   m_Size:
-    m_Target: 0.8660254
+    m_Target: 5.037119
     speed: 2
-    m_Value: 0.8660254
+    m_Value: 5.037119
   m_Ortho:
     m_Target: 1
     speed: 2
@@ -679,7 +579,7 @@ MonoBehaviour:
   m_SceneVisActive: 1
   m_LastLockedObject: {fileID: 0}
   m_ViewIsLockedToObject: 0
---- !u!114 &16
+--- !u!114 &12
 MonoBehaviour:
   m_ObjectHideFlags: 52
   m_CorrespondingSourceObject: {fileID: 0}
@@ -699,10 +599,10 @@ MonoBehaviour:
     m_Tooltip: 
   m_Pos:
     serializedVersion: 2
-    x: 0
-    y: 492
-    width: 747.5
-    height: 367
+    x: 741
+    y: 73
+    width: 772
+    height: 926
   m_ViewDataDictionary: {fileID: 0}
   m_OverlayCanvas:
     m_LastAppliedPresetName: Default
@@ -713,7 +613,7 @@ MonoBehaviour:
   m_ShowGizmos: 0
   m_TargetDisplay: 0
   m_ClearColor: {r: 0, g: 0, b: 0, a: 0}
-  m_TargetSize: {x: 1440, y: 2960}
+  m_TargetSize: {x: 1080, y: 2400}
   m_TextureFilterMode: 0
   m_TextureHideFlags: 61
   m_RenderIMGUI: 1
@@ -722,23 +622,23 @@ MonoBehaviour:
   m_VSyncEnabled: 0
   m_Gizmos: 0
   m_Stats: 0
-  m_SelectedSizes: 07000000000000000000000000000000000000000000000000000000000000000000000000000000
+  m_SelectedSizes: 08000000000000000000000000000000000000000000000000000000000000000000000000000000
   m_ZoomArea:
     m_HRangeLocked: 0
     m_VRangeLocked: 0
     hZoomLockedByDefault: 0
     vZoomLockedByDefault: 0
-    m_HBaseRangeMin: -360
-    m_HBaseRangeMax: 360
-    m_VBaseRangeMin: -740
-    m_VBaseRangeMax: 740
+    m_HBaseRangeMin: -540
+    m_HBaseRangeMax: 540
+    m_VBaseRangeMin: -1200
+    m_VBaseRangeMax: 1200
     m_HAllowExceedBaseRangeMin: 1
     m_HAllowExceedBaseRangeMax: 1
     m_VAllowExceedBaseRangeMin: 1
     m_VAllowExceedBaseRangeMax: 1
     m_ScaleWithWindow: 0
     m_HSlider: 0
-    m_VSlider: 1
+    m_VSlider: 0
     m_IgnoreScrollWheelUntilClicked: 0
     m_EnableMouseInput: 1
     m_EnableSliderZoomHorizontal: 0
@@ -749,29 +649,29 @@ MonoBehaviour:
       serializedVersion: 2
       x: 0
       y: 21
-      width: 747.5
-      height: 346
-    m_Scale: {x: 0.46695295, y: 0.46695295}
-    m_Translation: {x: 373.75, y: 0.45481205}
+      width: 772
+      height: 905
+    m_Scale: {x: 0.37708333, y: 0.37708333}
+    m_Translation: {x: 386, y: 452.5}
     m_MarginLeft: 0
     m_MarginRight: 0
     m_MarginTop: 0
     m_MarginBottom: 0
     m_LastShownAreaInsideMargins:
       serializedVersion: 2
-      x: -800.40186
-      y: -0.97399974
-      width: 1600.8037
-      height: 740.974
+      x: -1023.6464
+      y: -1200
+      width: 2047.2928
+      height: 2400
     m_MinimalGUI: 1
-  m_defaultScale: 0.23378378
-  m_LastWindowPixelSize: {x: 1495, y: 734}
+  m_defaultScale: 0.37708333
+  m_LastWindowPixelSize: {x: 772, y: 926}
   m_ClearInEditMode: 1
   m_NoCameraWarning: 1
-  m_LowResolutionForAspectRatios: 00000000000000000000
+  m_LowResolutionForAspectRatios: 01000000000000000000
   m_XRRenderMode: 0
   m_RenderTexture: {fileID: 0}
---- !u!114 &17
+--- !u!114 &13
 MonoBehaviour:
   m_ObjectHideFlags: 52
   m_CorrespondingSourceObject: {fileID: 0}
@@ -791,10 +691,10 @@ MonoBehaviour:
     m_Tooltip: 
   m_Pos:
     serializedVersion: 2
-    x: 748.5
-    y: 83
-    width: 357
-    height: 387
+    x: 1515
+    y: 554
+    width: 404
+    height: 445
   m_ViewDataDictionary: {fileID: 0}
   m_OverlayCanvas:
     m_LastAppliedPresetName: Default
@@ -804,7 +704,7 @@ MonoBehaviour:
       scrollPos: {x: 0, y: 0}
       m_SelectedIDs: 
       m_LastClickedID: 0
-      m_ExpandedIDs: 24fbffff
+      m_ExpandedIDs: 26fbffff
       m_RenameOverlay:
         m_UserAcceptedRename: 0
         m_Name: 
@@ -820,7 +720,7 @@ MonoBehaviour:
         m_IsRenaming: 0
         m_OriginalEventType: 11
         m_IsRenamingFilename: 0
-        m_ClientGUIView: {fileID: 10}
+        m_ClientGUIView: {fileID: 9}
       m_SearchString: 
     m_ExpandedScenes: []
     m_CurrenRootInstanceID: 0
@@ -828,7 +728,7 @@ MonoBehaviour:
       m_IsLocked: 0
     m_CurrentSortingName: TransformSorting
   m_WindowGUID: e3bbe22edb59341438698bcf22ae845f
---- !u!114 &18
+--- !u!114 &14
 MonoBehaviour:
   m_ObjectHideFlags: 52
   m_CorrespondingSourceObject: {fileID: 0}
@@ -848,16 +748,16 @@ MonoBehaviour:
     m_Tooltip: 
   m_Pos:
     serializedVersion: 2
-    x: 748.5
-    y: 491
-    width: 357
-    height: 368
+    x: 1515
+    y: 73
+    width: 404
+    height: 460
   m_ViewDataDictionary: {fileID: 0}
   m_OverlayCanvas:
     m_LastAppliedPresetName: Default
     m_SaveData: []
   m_SearchFilter:
-    m_NameFilter: enemy
+    m_NameFilter: 
     m_ClassNames: []
     m_AssetLabels: []
     m_AssetBundleNames: []
@@ -869,22 +769,22 @@ MonoBehaviour:
     m_SkipHidden: 0
     m_SearchArea: 1
     m_Folders:
-    - Assets/ScriptableObject
+    - Assets/Scripts/JsonConverter
     m_Globs: []
-    m_OriginalText: enemy
+    m_OriginalText: 
   m_ViewMode: 1
   m_StartGridSize: 16
   m_LastFolders:
-  - Assets/ScriptableObject
+  - Assets/Scripts/JsonConverter
   m_LastFoldersGridSize: 16
-  m_LastProjectPath: /Users/gyyu/Unity/RandomDiceDefense42-Client
+  m_LastProjectPath: D:\Unity\RandomDice42
   m_LockTracker:
     m_IsLocked: 0
   m_FolderTreeState:
     scrollPos: {x: 0, y: 0}
-    m_SelectedIDs: b0620000
-    m_LastClickedID: 25264
-    m_ExpandedIDs: 000000009862000000ca9a3b
+    m_SelectedIDs: be620000
+    m_LastClickedID: 25278
+    m_ExpandedIDs: 00000000606200006262000064620000
     m_RenameOverlay:
       m_UserAcceptedRename: 0
       m_Name: 
@@ -912,7 +812,7 @@ MonoBehaviour:
     scrollPos: {x: 0, y: 0}
     m_SelectedIDs: 
     m_LastClickedID: 0
-    m_ExpandedIDs: 0000000098620000
+    m_ExpandedIDs: 00000000606200006262000064620000
     m_RenameOverlay:
       m_UserAcceptedRename: 0
       m_Name: 
@@ -937,8 +837,8 @@ MonoBehaviour:
       m_Icon: {fileID: 0}
       m_ResourceFile: 
   m_ListAreaState:
-    m_SelectedInstanceIDs: 
-    m_LastClickedInstanceID: 0
+    m_SelectedInstanceIDs: 924dfaff
+    m_LastClickedInstanceID: -373358
     m_HadKeyboardFocusLastEvent: 0
     m_ExpandedInstanceIDs: 
     m_RenameOverlay:
@@ -956,7 +856,7 @@ MonoBehaviour:
       m_IsRenaming: 0
       m_OriginalEventType: 11
       m_IsRenamingFilename: 1
-      m_ClientGUIView: {fileID: 11}
+      m_ClientGUIView: {fileID: 9}
     m_CreateAssetUtility:
       m_EndAction: {fileID: 0}
       m_InstanceID: 0
@@ -968,7 +868,7 @@ MonoBehaviour:
     m_GridSize: 16
   m_SkipHiddenPackages: 0
   m_DirectoriesAreaWidth: 113
---- !u!114 &19
+--- !u!114 &15
 MonoBehaviour:
   m_ObjectHideFlags: 52
   m_CorrespondingSourceObject: {fileID: 0}
@@ -984,14 +884,14 @@ MonoBehaviour:
   m_MaxSize: {x: 4000, y: 4000}
   m_TitleContent:
     m_Text: Inspector
-    m_Image: {fileID: -440750813802333266, guid: 0000000000000000d000000000000000, type: 0}
+    m_Image: {fileID: -2667387946076563598, guid: 0000000000000000d000000000000000, type: 0}
     m_Tooltip: 
   m_Pos:
     serializedVersion: 2
-    x: 1107.5
-    y: 83
-    width: 331.5
-    height: 384
+    x: 1515
+    y: 73
+    width: 404
+    height: 460
   m_ViewDataDictionary: {fileID: 0}
   m_OverlayCanvas:
     m_LastAppliedPresetName: Default
@@ -1003,13 +903,13 @@ MonoBehaviour:
     m_ControlHash: -371814159
     m_PrefName: Preview_InspectorPreview
   m_LastInspectedObjectInstanceID: -1
-  m_LastVerticalScrollValue: 433.90018
+  m_LastVerticalScrollValue: 0
   m_GlobalObjectId: 
   m_InspectorMode: 0
   m_LockTracker:
     m_IsLocked: 0
   m_PreviewWindow: {fileID: 0}
---- !u!114 &20
+--- !u!114 &16
 MonoBehaviour:
   m_ObjectHideFlags: 52
   m_CorrespondingSourceObject: {fileID: 0}
@@ -1029,10 +929,10 @@ MonoBehaviour:
     m_Tooltip: 
   m_Pos:
     serializedVersion: 2
-    x: 1107.5
-    y: 488
-    width: 331.5
-    height: 371
+    x: 1515
+    y: 554
+    width: 404
+    height: 445
   m_ViewDataDictionary: {fileID: 0}
   m_OverlayCanvas:
     m_LastAppliedPresetName: Default


### PR DESCRIPTION
1. 시나리오 매니저를 구현했습니다.
 - 시나리오 매니저는 JSON컨버터를 소유하여 컨버터를 이용해 Json파일로 저장된 시나리오 데이터들을 읽어들여 전체적인 값을 갖고 있습니다.
 - json파일은 `Asset/JsonData`에 저장되어 있습니다.
 - 시나리오 매니저는 적 매니저가 waiting 상태이면 현재 시나리오 데이터를 주입하여 적 매니저가 적들을 데이터에 따라 스폰하게 합니다.

2. 시나리오 매니저의 개발에 따라 적 매니저 코드를 일부 수정하였습니다.
 - 적 매니저가 현재 시나리오 정보를 갖게 됩니다. (_currentWave 변수)
 - 적 매니저는 다음과 같은 상태를 갖게 됩니다. 상태는 update함수 내에서 실시간으로 확인되고 변경됩니다.
   -  현재 시나리오 정보 내 스폰할 적이 남아있으면 spawning
   -  시나리오 정보가 존재하지 않지만 적 라인에 아직 적이 남아있으면 spawnEnd
   -  시나리오 정보도, 라인에도 적이 남아있지 않으면 waiting
 - 현재 시나리오 정보가 비어있지 않으면 적 매니저는 시나리오에 내재된 변수(체력오프셋, 딜레이 등)에 따라 순차적으로 적을 스폰합니다.
 - 적 매니저가 제공하는 기본 타겟을 수정하여 맨 앞의, 맨 뒤의, 가장 체력이 많은, 랜덤한 적을 타깃하도록 하였습니다.

2. 시나리오 매니저에 개발에 따라 적의 코드를 일부 수정하였습니다.
 - 이제 적은 제공받는 타입에 따라 적의 타입이 결정됩니다.
 - 이제 적은 제공받는 체력 오프셋에 따라 초기화될 때 최대체력이 변경됩니다.

아래는 시연 gif입니다.
![ScenarioManaging](https://user-images.githubusercontent.com/42938826/196158739-21c63728-7406-447c-8d2c-e0016aba15ea.gif)

close #53 
